### PR TITLE
Update call to width and height of planeGeometry

### DIFF
--- a/chapter-02/01-basic-scene.html
+++ b/chapter-02/01-basic-scene.html
@@ -106,9 +106,9 @@
 
 
                 // position the cube randomly in the scene
-                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.width));
+                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.parameters.width));
                 cube.position.y= Math.round((Math.random() * 5));
-                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.height));
+                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.parameters.height));
 
                 // add the cube to the scene
                 scene.add(cube);

--- a/chapter-02/02-foggy-scene.html
+++ b/chapter-02/02-foggy-scene.html
@@ -106,9 +106,9 @@
                 cube.castShadow = true;
 
                 // position the cube randomly in the scene
-                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.width));
+                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.parameters.width));
                 cube.position.y= Math.round((Math.random() * 5));
-                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.height));
+                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.parameters.height));
 
                 // add the cube to the scene
                 scene.add(cube);

--- a/chapter-02/03-forced-materials.html
+++ b/chapter-02/03-forced-materials.html
@@ -105,9 +105,9 @@
                 cube.castShadow = true;
 
                 // position the cube randomly in the scene
-                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.width));
+                cube.position.x=-30 + Math.round((Math.random() * planeGeometry.parameters.width));
                 cube.position.y= Math.round((Math.random() * 5));
-                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.height));
+                cube.position.z=-20 + Math.round((Math.random() * planeGeometry.parameters.height));
 
                 // add the cube to the scene
                 scene.add(cube);


### PR DESCRIPTION
Chapter-02: `planeGeometry.width` and `planeGeometry.height` return `undefined` as of **r69** thus resulting in `NaN` in `cube.position.x` and `cube.position.z` 

Fixed to `planeGeometry.parameters.width` and `planeGeometry.parameters.height`
